### PR TITLE
Problem: we don't handle target-pool orphans

### DIFF
--- a/delete-orphaned-kube-network-load-balancers.sh
+++ b/delete-orphaned-kube-network-load-balancers.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# vim: ts=4:sw=4
 #
 # A utility for deleting google cloud network load-balancers that are unattached to active
 # kubernetes' services.
@@ -28,6 +29,9 @@ REGION=${REGION:-}
 KUBE_CONTEXT=${KUBE_CONTEXT:-}
 GKE_CLUSTER_NAME=${GKE_CLUSTER_NAME:-}
 
+total=0
+deleted=0
+verb="should be deleted"
 
 #######################################
 # Check required enviroement is setup
@@ -53,7 +57,7 @@ validate() {
 #   0 - the firewall-rule is in use
 #   1 - the firewall-rule is not in use
 #######################################
-valid() {
+valid_firewall() {
     local id="$1"
     local fw_json description service_name ip
 
@@ -69,6 +73,8 @@ valid() {
         return 1
     fi
 
+
+    # does it have a valid front end
     echo "  IN USE by the kube cluster"
     return 0
 }
@@ -98,41 +104,92 @@ delete_gce_lb_objects() {
     set -e
 }
 
-main() {
-    validate
-
+check_firewalls() {
     ACTIVE_IPS=$(kubectl --context="${KUBE_CONTEXT}" get services --all-namespaces -o json | jq -r '.items[].status.loadBalancer.ingress[0].ip' | sort | uniq)
     if [[ -z "$ACTIVE_IPS" ]]; then
         echo "ERROR: failed to get a list of public service IP's from the kube cluster"
         exit 1
     fi
 
-    total=0
-    deleted=0
 
-    verb="should be deleted"
     LIST=$(gcloud "--project=${PROJECT}" compute firewall-rules list \
-            --format='value(name)' \
-            --filter="name ~ ^k8s-fw- AND -tags gke-${GKE_CLUSTER_NAME}-")
+        --format='value(name)' \
+        --filter="name ~ ^k8s-fw- AND -tags gke-${GKE_CLUSTER_NAME}-")
     for x in ${LIST}; do
-        if ! valid "$x"; then
+        if ! valid_firewall "$x"; then
             # extract the 32-char "id", ex: "k8s-fw-a018702dbb5d111e6bdee42010af0012" => "a018702dbb5d111e6bdee42010af0012"
             # since the other objects use only the id as their name while firewall-rules use a 'k8s-fw-' prefix for their name.
             local kube_id
             kube_id=$(sed 's/.*k8s-fw-\([a-z0-9]\{32\}\).*/\1/' <<<"${x}")
 
             if [[ -z "$DRYRUN" ]] ; then
-              verb="deleted"
-              echo "  DELETING $kube_id, this will take several minutes ..."
-              delete_gce_lb_objects "$kube_id"
+                echo "  DELETING $kube_id, this will take several minutes ..."
+                delete_gce_lb_objects "$kube_id"
             fi
             deleted=$((deleted + 1))
         fi
         total=$((total + 1))
     done
 
+}
+
+valid_target_pool() {
+    targets=$1
+    for i in $targets ; do
+        if grep -q "$targets" <<<"$current_nodes" ; then
+            #echo " -> target node $i in use!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+            return 0
+        fi
+    done
+    #echo " -> No endpoints exist for this target"
+    return 1
+}
+
+check_target_pools() {
+    delete=()
+
+    current_nodes=$(gcloud --project="$PROJECT" compute instances list --format='value(name)' )
+    targets=$(gcloud --project="$PROJECT" compute target-pools list --format='value(name)' --filter="region:( $REGION )")
+    current_forwarding_rules=$(gcloud --project="$PROJECT" compute forwarding-rules list --format='value(name)'  )
+    for tp in $targets ; do
+        echo "checking target $tp"
+        total=$(( total + 1 ))
+
+        target_nodes=$(gcloud --project="$PROJECT" compute target-pools describe "$tp" --region="$REGION"  | grep zone | grep instances | awk -F/  '{print $11}')
+        if ! valid_target_pool "$target_nodes"; then
+            echo " => no hosts in target pool; should delete"
+            delete+=("$tp")
+            continue
+        fi
+
+        # check if theres a forwarding rule for this target pool, if not it's orphaned
+        if ! grep -q "$tp" <<<"$current_forwarding_rules"; then
+            echo "=> no forwarding rule; should delete $tp"
+            delete+=("$tp")
+            continue
+        fi
+    done
+    deleted=$(( deleted + ${#delete[@]} ))
+
+    for i in "${delete[@]}" ; do
+        if [[ -z "$DRYRUN" ]] ; then
+            echo "DELETING target pool and associated objects $i"
+            delete_gce_lb_objects "$i"
+        fi
+    done
+}
+
+main() {
+    if [[ -z "$DRYRUN" ]] ; then
+        verb="Deleted"
+    fi
+
+    validate
+    check_target_pools
+    check_firewalls
+
     echo "$verb: $deleted"
-    echo "total scanned: $total"
+    echo "scanned: $total"
 }
 
 main


### PR DESCRIPTION
There are 2 known issues where pools can be orphaned.
1) when a pool has no endpoints
2) when a pool has no associated forwarding rule

Both of these are invalid, and these additions detect target pools in
this state.

This check is a bit more risky in that we can't see if it's a directly
kube-managed resource, but pools in this configuration are probably not
meant to lay around anyhow.

There is another 3rd issue with kube target-pools, which is when a pool
has no associated health-check, and this PR does nothing to handle that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pantheon-systems/kube-gce-cleanup/4)
<!-- Reviewable:end -->
